### PR TITLE
Fixing bug on embedded n_tail_segments property

### DIFF
--- a/bouter/embedded/__init__.py
+++ b/bouter/embedded/__init__.py
@@ -8,7 +8,10 @@ from bouter import Experiment
 class EmbeddedExperiment(Experiment):
     @property
     def n_tail_segments(self):
-        return self["behavior"]["tail"]["n_segments"]
+        try:
+            return self["behavior"]["tail"]["n_segments"]
+        except KeyError:
+            return self["tracking+tail_tracking"]["n_segments"]
 
     @property
     def tail_columns(self):


### PR DESCRIPTION
The current version of the embedded code is only running for old stytra datasets, not for recently-acquired ones. Issues have to do with the logging (currently, loading of n_segments tracked).

I added a quick fix that does not seem to do the trick, so I open this PR to fix this and add the pertinent examples and tests when I have the time.