### PR TITLE
Add NeurodataWithoutBorders conversion

### DIFF
--- a/bouter/nwb/conversion.py
+++ b/bouter/nwb/conversion.py
@@ -1,14 +1,14 @@
-import numpy as np
-
-from functools import singledispatch
 from datetime import datetime
+from functools import singledispatch
 from pathlib import Path
 
-from bouter import Experiment
-from bouter.free import FreelySwimmingExperiment
-from bouter.embedded import EmbeddedExperiment
-from pynwb import NWBFile, NWBHDF5IO
+import numpy as np
+from pynwb import NWBFile, NWBHDF5IO, TimeSeries
 from pynwb.misc import AbstractFeatureSeries
+
+from bouter import Experiment
+from bouter.embedded import EmbeddedExperiment
+from bouter.free import FreelySwimmingExperiment
 
 
 def _save_stimulus(exp: Experiment, nwbfile: NWBFile):
@@ -58,7 +58,9 @@ def _(exp: FreelySwimmingExperiment, nwbfile: NWBFile):
 
 @_save_behavior.register
 def _(exp: EmbeddedExperiment, nwbfile: NWBFile):
-    raise NotImplementedError("Freely-swimming experiment serialization not yet implemented")
+    tail_shapes = TimeSeries("tail_shape", timestamps=exp.behavior_log.t.values,
+                             data=exp.behavior_log.loc[:, exp.tail_columns].values, unit="radians")
+    nwbfile.add_acquisition(tail_shapes)
 
 
 def experiment_to_nwb(exp: Experiment, nwb_path: Path):

--- a/bouter/nwb/conversion.py
+++ b/bouter/nwb/conversion.py
@@ -1,0 +1,76 @@
+import numpy as np
+
+from functools import singledispatch
+from datetime import datetime
+from pathlib import Path
+
+from bouter import Experiment
+from bouter.free import FreelySwimmingExperiment
+from bouter.embedded import EmbeddedExperiment
+from pynwb import NWBFile, NWBHDF5IO
+from pynwb.misc import AbstractFeatureSeries
+
+
+def _save_stimulus(exp: Experiment, nwbfile: NWBFile):
+    """Converts the stimulus log into two time NWB time series, one
+    for the floating point and the other for integer values"""
+    float_columns = []
+    int_columns = []
+    for col in exp.stimulus_log.columns:
+        if np.issubdtype(exp.stimulus_log[col].dtype, np.floating):
+            float_columns.append(col)
+        elif np.issubdtype(exp.stimulus_log[col].dtype, np.integer):
+            int_columns.append(col)
+        else:
+            raise NotImplementedError(
+                f"Serialization of {exp.stimulus_log[col].dtype}"
+                f"into NWB not supported for column {col} of the stimulus log."
+            )
+    nontime_float_columns = [col for col in float_columns if col != "t"]
+    stimulus_features_float = AbstractFeatureSeries(
+        name="stimulus_features_int",
+        features=nontime_float_columns,
+        feature_units=["" for _ in nontime_float_columns],
+        data=exp.stimulus_log.loc[:, nontime_float_columns].values,
+        timestamps=exp.stimulus_log.t.values,
+    )
+
+    stimulus_features_int = AbstractFeatureSeries(
+        name="stimlus_features_float",
+        features=int_columns,
+        feature_units=["" for _ in nontime_float_columns],
+        data=exp.stimulus_log.loc[:, nontime_float_columns].values,
+        timestamps=stimulus_features_float,
+    )
+    nwbfile.add_stimulus(stimulus_features_float)
+    nwbfile.add_stimulus(stimulus_features_int)
+
+
+@singledispatch
+def _save_behavior(exp: Experiment, nwbfile: NWBFile):
+    pass
+
+
+@_save_behavior.register
+def _(exp: FreelySwimmingExperiment, nwbfile: NWBFile):
+    raise NotImplementedError("Freely-swimming experiment serialization not yet implemented")
+
+
+@_save_behavior.register
+def _(exp: EmbeddedExperiment, nwbfile: NWBFile):
+    raise NotImplementedError("Freely-swimming experiment serialization not yet implemented")
+
+
+def experiment_to_nwb(exp: Experiment, nwb_path: Path):
+    nwbfile = NWBFile(
+        session_description="demonstrate adding to an NWB file",
+        identifier=exp.full_name,
+        session_start_time=datetime.fromisoformat(exp["general"]["t_protocol_start"]),
+    )
+
+    _save_stimulus(exp, nwbfile)
+
+    nwbfile.save()
+
+    with NWBHDF5IO(nwb_path, "w") as io:
+        io.write(nwbfile)

--- a/bouter/nwb/conversion.py
+++ b/bouter/nwb/conversion.py
@@ -6,10 +6,9 @@ from pathlib import Path
 
 import numpy as np
 import pynwb.file
+from ndx_zebrafish import ZebrafishBehavior
 from pynwb import NWBHDF5IO, NWBFile
 from pynwb.misc import AbstractFeatureSeries
-
-from ndx_zebrafish import ZebrafishBehavior
 
 from bouter import Experiment, df_utilities
 from bouter.embedded import EmbeddedExperiment
@@ -149,7 +148,7 @@ def _(exp: FreelySwimmingExperiment, nwbfile: NWBFile):
 @_save_behavior.register
 def _(exp: EmbeddedExperiment, nwbfile: NWBFile):
     tail_shapes = ZebrafishBehavior(
-        name=f"embedded_behavior",
+        name="embedded_behavior",
         fish_id=0,
         tail_shape=pynwb.behavior.SpatialSeries(
             "tail_shape",

--- a/bouter/nwb/conversion.py
+++ b/bouter/nwb/conversion.py
@@ -6,12 +6,16 @@ from pathlib import Path
 
 import numpy as np
 import pynwb.file
-from pynwb import NWBFile, NWBHDF5IO, TimeSeries
+from pynwb import NWBFile, NWBHDF5IO
 from pynwb.misc import AbstractFeatureSeries
 
 from bouter import Experiment
+from bouter import df_utilities
 from bouter.embedded import EmbeddedExperiment
 from bouter.free import FreelySwimmingExperiment
+
+REFERENCE_FRAME_DESCRIPTION = "left-handed coordinate system with the x axis pointing rightward in the camera view"
+TAIL_SHAPE_REFERENCE_FRAME_DESCRIPTION = "relative tail angles"
 
 
 def _get_subject_metadata(exp: Experiment):
@@ -23,7 +27,7 @@ def _get_subject_metadata(exp: Experiment):
         description=exp["general"]["animal"]["comments"],
         genotype=exp["general"]["animal"]["genotype"],
         species=exp["general"]["animal"]["species"],
-        subject_id=exp["general"]["animal"]["id"],
+        subject_id=str(exp["general"]["animal"]["id"]),
     )
 
 
@@ -102,23 +106,51 @@ def _save_behavior(exp: Experiment, nwbfile: NWBFile):
 
 @_save_behavior.register
 def _(exp: FreelySwimmingExperiment, nwbfile: NWBFile):
-    raise NotImplementedError(
-        "Freely-swimming experiment serialization not yet implemented"
-    )
+    for i_fish in range(exp.n_fish):
+        fish_data = exp._rename_fish(
+            exp.behavior_log, i_fish, exp.n_tail_segments
+        )
+        tail_direction = pynwb.behavior.SpatialSeries(
+            "fish_direction",
+            fish_data.loc[:, "theta"].values,
+            timestamps=fish_data.t.values,
+            reference_frame=REFERENCE_FRAME_DESCRIPTION,
+        )
+        tail_shape = pynwb.behavior.SpatialSeries(
+            "tail_shape",
+            fish_data.loc[
+                :, df_utilities.tail_column_names(exp.n_tail_segments)
+            ].values,
+            timestamps=tail_direction,
+            unit="radians",
+            reference_frame=TAIL_SHAPE_REFERENCE_FRAME_DESCRIPTION,
+        )
+        position = pynwb.behavior.SpatialSeries(
+            "fish_position",
+            fish_data.loc[:, ["x", "y"]].values * exp.camera_px_in_mm,
+            timestamps=tail_direction,
+            unit="mm",
+            reference_frame=REFERENCE_FRAME_DESCRIPTION,
+        )
+        per_fish_data = pynwb.behavior.Position(
+            [position, tail_direction, tail_shape], name=f"fish_{i_fish}"
+        )
+        nwbfile.add_acquisition(per_fish_data)
 
 
 @_save_behavior.register
 def _(exp: EmbeddedExperiment, nwbfile: NWBFile):
-    tail_shapes = TimeSeries(
+    tail_shapes = pynwb.behavior.SpatialSeries(
         "tail_shape",
         timestamps=exp.behavior_log.t.values,
         data=exp.behavior_log.loc[:, exp.tail_columns].values,
         unit="radians",
+        reference_frame=TAIL_SHAPE_REFERENCE_FRAME_DESCRIPTION,
     )
     nwbfile.add_acquisition(tail_shapes)
 
 
-def experiment_to_nwb(exp: Experiment, nwb_path: Path):
+def experiment_to_nwb(exp: Experiment, nwb_path: Path) -> pynwb.NWBFile:
     """Convert a bouter Experiment into a nwb file."""
     nwbfile = NWBFile(
         session_description="demonstrate adding to an NWB file",
@@ -131,8 +163,9 @@ def experiment_to_nwb(exp: Experiment, nwb_path: Path):
     )
 
     _save_stimulus(exp, nwbfile)
-
-    nwbfile.save()
+    _save_behavior(exp, nwbfile)
 
     with NWBHDF5IO(nwb_path, "w") as io:
         io.write(nwbfile)
+
+    return nwbfile

--- a/bouter/nwb/conversion.py
+++ b/bouter/nwb/conversion.py
@@ -9,8 +9,8 @@ import pynwb.file
 from pynwb import NWBFile, NWBHDF5IO
 from pynwb.misc import AbstractFeatureSeries
 
-from bouter import Experiment
 from bouter import df_utilities
+from bouter import Experiment
 from bouter.embedded import EmbeddedExperiment
 from bouter.free import FreelySwimmingExperiment
 

--- a/bouter/nwb/conversion.py
+++ b/bouter/nwb/conversion.py
@@ -1,8 +1,11 @@
+import json
+from copy import deepcopy
 from datetime import datetime
 from functools import singledispatch
 from pathlib import Path
 
 import numpy as np
+import pynwb.file
 from pynwb import NWBFile, NWBHDF5IO, TimeSeries
 from pynwb.misc import AbstractFeatureSeries
 
@@ -11,9 +14,30 @@ from bouter.embedded import EmbeddedExperiment
 from bouter.free import FreelySwimmingExperiment
 
 
+def _get_subject_metadata(exp: Experiment):
+    """Converts the metadata about the animal into
+    NWB subject metadata.
+    """
+    return pynwb.file.Subject(
+        age=f'P{exp["general"]["animal"]["age"]}D',
+        description=exp["general"]["animal"]["comments"],
+        genotype=exp["general"]["animal"]["genotype"],
+        species=exp["general"]["animal"]["species"],
+        subject_id=exp["general"]["animal"]["id"],
+    )
+
+
 def _save_stimulus(exp: Experiment, nwbfile: NWBFile):
     """Converts the stimulus log into two time NWB time series, one
-    for the floating point and the other for integer values"""
+    for the floating point and the other for integer values.
+
+    The stimuli in Stytra have two kinds of properties: static
+    ones determined at stimulus creation and dynamic ones that
+    depend on the behavior of the animal. The stimuli therefore
+    have to have two kinds of serialization, the TimeSeries-
+    based one (for the dynamic properties), and the other with
+
+    """
     float_columns = []
     int_columns = []
     for col in exp.stimulus_log.columns:
@@ -45,6 +69,31 @@ def _save_stimulus(exp: Experiment, nwbfile: NWBFile):
     nwbfile.add_stimulus(stimulus_features_float)
     nwbfile.add_stimulus(stimulus_features_int)
 
+    stimulus_intervals = pynwb.epoch.TimeIntervals(
+        name="stimulus_log", description="JSON-serialized stimulus log"
+    )
+
+    stimulus_intervals.add_column(
+        name="stimulus_name", description="stimulus name"
+    )
+    stimulus_intervals.add_column(
+        name="stimulus_data", description="JSON-encoded stimulus data"
+    )
+
+    for stim in exp["stimulus"]["log"]:
+        stim_copy = deepcopy(stim)
+        t_start = stim_copy.pop("t_start")
+        t_stop = stim_copy.pop("t_stop")
+        stim_name = stim_copy.pop("name")
+        stimulus_intervals.add_interval(
+            t_start,
+            t_stop,
+            stimulus_name=stim_name,
+            stimulus_data=json.dumps(stim_copy),
+        )
+
+    nwbfile.add_time_intervals(stimulus_intervals)
+
 
 @singledispatch
 def _save_behavior(exp: Experiment, nwbfile: NWBFile):
@@ -53,21 +102,32 @@ def _save_behavior(exp: Experiment, nwbfile: NWBFile):
 
 @_save_behavior.register
 def _(exp: FreelySwimmingExperiment, nwbfile: NWBFile):
-    raise NotImplementedError("Freely-swimming experiment serialization not yet implemented")
+    raise NotImplementedError(
+        "Freely-swimming experiment serialization not yet implemented"
+    )
 
 
 @_save_behavior.register
 def _(exp: EmbeddedExperiment, nwbfile: NWBFile):
-    tail_shapes = TimeSeries("tail_shape", timestamps=exp.behavior_log.t.values,
-                             data=exp.behavior_log.loc[:, exp.tail_columns].values, unit="radians")
+    tail_shapes = TimeSeries(
+        "tail_shape",
+        timestamps=exp.behavior_log.t.values,
+        data=exp.behavior_log.loc[:, exp.tail_columns].values,
+        unit="radians",
+    )
     nwbfile.add_acquisition(tail_shapes)
 
 
 def experiment_to_nwb(exp: Experiment, nwb_path: Path):
+    """Convert a bouter Experiment into a nwb file."""
     nwbfile = NWBFile(
         session_description="demonstrate adding to an NWB file",
         identifier=exp.full_name,
-        session_start_time=datetime.fromisoformat(exp["general"]["t_protocol_start"]),
+        session_start_time=datetime.fromisoformat(
+            exp["general"]["t_protocol_start"]
+        ),
+        subject=_get_subject_metadata(exp),
+        experimenter=exp["general"]["basic"]["experimenter_name"],
     )
 
     _save_stimulus(exp, nwbfile)

--- a/bouter/nwb/conversion.py
+++ b/bouter/nwb/conversion.py
@@ -6,11 +6,10 @@ from pathlib import Path
 
 import numpy as np
 import pynwb.file
-from pynwb import NWBFile, NWBHDF5IO
+from pynwb import NWBHDF5IO, NWBFile
 from pynwb.misc import AbstractFeatureSeries
 
-from bouter import df_utilities
-from bouter import Experiment
+from bouter import Experiment, df_utilities
 from bouter.embedded import EmbeddedExperiment
 from bouter.free import FreelySwimmingExperiment
 

--- a/bouter/tests/test_nwb_conversion.py
+++ b/bouter/tests/test_nwb_conversion.py
@@ -8,10 +8,10 @@ from bouter.nwb.conversion import experiment_to_nwb
 def test_convert_freely_swimming(freely_swimming_exp_path):
     exp = free.FreelySwimmingExperiment(freely_swimming_exp_path)
     tempdir = tempfile.mkdtemp()
-    nwb_exp = experiment_to_nwb(exp, Path(tempdir) / "free.nwb")
+    experiment_to_nwb(exp, Path(tempdir) / "free.nwb")
 
 
 def test_convert_embedded(embedded_exp_path):
     exp = embedded.EmbeddedExperiment(embedded_exp_path)
     tempdir = tempfile.mkdtemp()
-    nwb_exp = experiment_to_nwb(exp, Path(tempdir) / "embedded.nwb")
+    experiment_to_nwb(exp, Path(tempdir) / "embedded.nwb")

--- a/bouter/tests/test_nwb_conversion.py
+++ b/bouter/tests/test_nwb_conversion.py
@@ -1,0 +1,17 @@
+import tempfile
+from pathlib import Path
+
+from bouter import embedded, free
+from bouter.nwb.conversion import experiment_to_nwb
+
+
+def test_convert_freely_swimming(freely_swimming_exp_path):
+    exp = free.FreelySwimmingExperiment(freely_swimming_exp_path)
+    tempdir = tempfile.mkdtemp()
+    nwb_exp = experiment_to_nwb(exp, Path(tempdir) / "free.nwb")
+
+
+def test_convert_embedded(embedded_exp_path):
+    exp = embedded.EmbeddedExperiment(embedded_exp_path)
+    tempdir = tempfile.mkdtemp()
+    nwb_exp = experiment_to_nwb(exp, Path(tempdir) / "embedded.nwb")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pandas
 numba
 flammkuchen
 pynwb
+ndx-zebrafish

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy
 pandas
 numba
 flammkuchen
+pynwb


### PR DESCRIPTION
Implements conversion of Stytra experiments into the NeurodataWithoutBorders (NWB) format with correct semantics.

In this PR conversion of a `TailTracking` and `FreelySwimming` experiment is implemented, more generic conversions will be implemented once the required additional metadata is implemented in stytra (e.g. units for tracking).